### PR TITLE
Feature - add ubuntu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Default: 6379
 
 ## Limitations
 
-* Only tested on RHEL/CentOS 7
+* Only tested on RHEL/CentOS 7/Ubuntu 16.04
 
 ## Development
 

--- a/manifests/bot.pp
+++ b/manifests/bot.pp
@@ -57,11 +57,11 @@ define lita::bot (
     notify      => Service["lita_${_name}"],
   }
 
-  file { "/usr/lib/systemd/system/lita@${_name}.service.d":
+  file { "${::lita::service_path}/lita@${_name}.service.d":
     ensure  => 'directory',
   }
 
-  file { "/usr/lib/systemd/system/lita@${_name}.service.d/workingdir.conf":
+  file { "${::lita::service_path}/lita@${_name}.service.d/workingdir.conf":
     ensure  => file,
     owner   => root,
     group   => root,
@@ -69,7 +69,7 @@ define lita::bot (
     content => "[Service]\nWorkingDirectory=${bot_dir}\n",
   }
 
-  file { "/etc/sysconfig/lita-${_name}":
+  file { "${::lita::service_env_file}-${_name}":
     ensure  => file,
     content => "HOME=${bot_dir}\n",
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,8 @@ class lita (
   $bundler_provider = $::lita::params::bundler_provider,
   $bundler_binpath  = $::lita::params::bundler_binpath,
   $extra_packages   = $::lita::params::extra_packages,
+  $service_env_file = $::lita::params::service_env_file,
+  $service_path     = $::lita::params::service_path,
 
   # bot defaults
   $version          = $::lita::params::version,
@@ -38,7 +40,7 @@ class lita (
     ensure  => 'present',
     system  => true,
     gid     => 'lita',
-    home    => '/opt/lita',
+    home    => $base_path,
     shell   => '/bin/bash',
     require => Group['lita'],
   }
@@ -65,7 +67,7 @@ class lita (
     group  => 'lita',
   }
 
-  file { '/usr/lib/systemd/system/lita@.service':
+  file { "${service_path}/lita@.service":
     owner   => root,
     group   => root,
     mode    => '0555',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,17 +9,19 @@ class lita::params {
   $manage_bundler = false
   $bundler_package = 'bundler'
   $bundler_provider = 'gem'
-  $bundler_binpath = '/bin'
+  
   $extra_packages = []
   case $::osfamily {
     'Debian': {
       $service_env_file = '/etc/default/lita'
       $service_path     = '/lib/systemd/system'
+      $bundler_binpath  = '/usr/local/bin'
     }
 
     'RedHat': {
       $service_env_file = '/etc/sysconfig/lita'
       $service_path     = '/usr/lib/systemd/system'
+      $bundler_binpath  = '/bin'
     }
 
     default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,21 @@ class lita::params {
   $bundler_provider = 'gem'
   $bundler_binpath = '/bin'
   $extra_packages = []
+  case $::osfamily {
+    'Debian': {
+      $service_env_file = '/etc/default/lita'
+      $service_path     = '/lib/systemd/system'
+    }
+
+    'RedHat': {
+      $service_env_file = '/etc/sysconfig/lita'
+      $service_path     = '/usr/lib/systemd/system'
+    }
+
+    default: {
+      fail "Operating system ${::operatingsystem} is not supported yet."
+    }
+  }
 
   # bot
   $version = 'latest'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class lita::params {
   $manage_bundler = false
   $bundler_package = 'bundler'
   $bundler_provider = 'gem'
-  
+
   $extra_packages = []
   case $::osfamily {
     'Debian': {

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,8 @@
   "tags": ["lita", "jira"],
   "operatingsystem_support": [
     { "operatingsystem": "RedHat", "operatingsystemrelease": [ "7" ] },
-    { "operatingsystem": "CentOS", "operatingsystemrelease": [ "7" ] }
+    { "operatingsystem": "CentOS", "operatingsystemrelease": [ "7" ] },
+    { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "16.04", "16.10" ] }
   ],
   "dependencies": [
     { "name": "camptocamp/systemd", "version_requirement": ">=0.1.0 <1.0.0" },

--- a/templates/lita.service.erb
+++ b/templates/lita.service.erb
@@ -3,7 +3,7 @@ Description=Lita (%i) bot
 After=network.target
 
 [Service]
-EnvironmentFile=-/etc/sysconfig/lita-%i
+EnvironmentFile=-<%= @service_env_file %>-%i
 Type=simple
 ExecStart=<%= @bundler_binpath %>/bundle exec lita
 ExecReload=<%= @bundler_binpath %>/bundle exec lita


### PR DESCRIPTION
Minor tweaks throughout to add support for Ubuntu. Might also work for Debian 7, but I haven't tried that yet. Works for Ubuntu 16.04, assuming you've installed the required `ruby-dev`, `gcc`, and `make` packages.
